### PR TITLE
chore(package.json): downgrade "@aws-sdk/client-s3" to version 3.370.0

### DIFF
--- a/lib/storage/minio.ts
+++ b/lib/storage/minio.ts
@@ -4,13 +4,11 @@ import {
   S3Client,
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import { FetchHttpHandler } from '@smithy/fetch-http-handler';
 
 import env from '@/lib/env';
 
 const s3 = new S3Client({
   region: env.storage.region ? env.storage.region : 'us-east-1',
-  requestHandler: new FetchHttpHandler({ keepAlive: false }),
   credentials: {
     accessKeyId: env.storage.accessKey
       ? env.storage.accessKey

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@aws-sdk/client-s3": "^3.425.0",
+        "@aws-sdk/client-s3": "^3.370.0",
         "@aws-sdk/s3-request-presigner": "^3.427.0",
         "@boxyhq/saml-jackson": "1.12.1",
         "@heroicons/react": "2.0.18",
@@ -18,7 +18,6 @@
         "@prisma/client": "^5.1.1",
         "@retracedhq/logs-viewer": "2.5.1",
         "@retracedhq/retraced": "0.7.0",
-        "@smithy/fetch-http-handler": "^2.2.2",
         "@tailwindcss/typography": "0.5.9",
         "autoprefixer": "10.4.15",
         "axios": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "postinstall": "npx prisma generate"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.425.0",
+    "@aws-sdk/client-s3": "^3.370.0",
     "@aws-sdk/s3-request-presigner": "^3.427.0",
     "@boxyhq/saml-jackson": "1.12.1",
     "@heroicons/react": "2.0.18",
@@ -30,7 +30,6 @@
     "@prisma/client": "^5.1.1",
     "@retracedhq/logs-viewer": "2.5.1",
     "@retracedhq/retraced": "0.7.0",
-    "@smithy/fetch-http-handler": "^2.2.2",
     "@tailwindcss/typography": "0.5.9",
     "autoprefixer": "10.4.15",
     "axios": "1.4.0",


### PR DESCRIPTION
fix(minio.ts): remove unused import of FetchHttpHandler to improve code cleanliness and reduce unnecessary dependencies
chore(package.json): downgrade "@aws-sdk/client-s3" to version 3.370.0 to match other dependencies and maintain compatibility