### PR TITLE
fix(minio.ts): import FetchHttpHandler from @smithy/fetch-http-handler

### DIFF
--- a/lib/storage/minio.ts
+++ b/lib/storage/minio.ts
@@ -1,3 +1,4 @@
+import { FetchHttpHandler } from '@smithy/fetch-http-handler';
 import {
   GetObjectCommand,
   PutObjectCommand,
@@ -9,6 +10,7 @@ import env from '@/lib/env';
 
 const s3 = new S3Client({
   region: env.storage.region ? env.storage.region : 'us-east-1',
+  requestHandler: new FetchHttpHandler({ keepAlive: false }),
   credentials: {
     accessKeyId: env.storage.accessKey
       ? env.storage.accessKey

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@prisma/client": "^5.1.1",
         "@retracedhq/logs-viewer": "2.5.1",
         "@retracedhq/retraced": "0.7.0",
+        "@smithy/fetch-http-handler": "^2.2.3",
         "@tailwindcss/typography": "0.5.9",
         "autoprefixer": "10.4.15",
         "axios": "1.4.0",
@@ -4119,9 +4120,9 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.2.tgz",
-      "integrity": "sha512-K7aRtRuaBjzlk+jWWeyfDTLAmRRvmA4fU8eHUXtjsuEDgi3f356ZE32VD2ssxIH13RCLVZbXMt5h7wHzYiSuVA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.3.tgz",
+      "integrity": "sha512-0G9sePU+0R+8d7cie+OXzNbbkjnD4RfBlVCs46ZEuQAMcxK8OniemYXSSkOc80CCk8Il4DnlYZcUSvsIs2OB2w==",
       "dependencies": {
         "@smithy/protocol-http": "^3.0.7",
         "@smithy/querystring-builder": "^2.0.11",
@@ -19102,9 +19103,9 @@
       }
     },
     "@smithy/fetch-http-handler": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.2.tgz",
-      "integrity": "sha512-K7aRtRuaBjzlk+jWWeyfDTLAmRRvmA4fU8eHUXtjsuEDgi3f356ZE32VD2ssxIH13RCLVZbXMt5h7wHzYiSuVA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.3.tgz",
+      "integrity": "sha512-0G9sePU+0R+8d7cie+OXzNbbkjnD4RfBlVCs46ZEuQAMcxK8OniemYXSSkOc80CCk8Il4DnlYZcUSvsIs2OB2w==",
       "requires": {
         "@smithy/protocol-http": "^3.0.7",
         "@smithy/querystring-builder": "^2.0.11",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@prisma/client": "^5.1.1",
     "@retracedhq/logs-viewer": "2.5.1",
     "@retracedhq/retraced": "0.7.0",
+    "@smithy/fetch-http-handler": "^2.2.3",
     "@tailwindcss/typography": "0.5.9",
     "autoprefixer": "10.4.15",
     "axios": "1.4.0",


### PR DESCRIPTION
fix(minio.ts): import FetchHttpHandler from @smithy/fetch-http-handler to resolve missing import error
feat(minio.ts): add FetchHttpHandler as the request handler for S3Client to improve performance by disabling keep-alive
chore(package.json): add @smithy/fetch-http-handler as a dependency to enable the use of FetchHttpHandler in minio.ts