### PR TITLE
chore(package.json): remove unnecessary prisma commands from build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docker": "./scripts/dev.sh",
     "dev": "next dev --port 4002",
-    "build": "prisma generate && prisma db push --accept-data-loss && next build",
+    "build": "next build",
     "start": "next start --port 4002",
     "check-types": "tsc --pretty --noEmit",
     "check-format": "prettier --check .",


### PR DESCRIPTION
chore(package.json): remove unnecessary prisma commands from build script
The build script in package.json was updated to remove the unnecessary prisma commands. These commands were not needed for the build process and were causing confusion.