### PR TITLE
fix(CreateTask.tsx): remove unnecessary teamId field

### DIFF
--- a/components/tasks/CreateTask.tsx
+++ b/components/tasks/CreateTask.tsx
@@ -31,14 +31,12 @@ const CreateTask = ({
       language: languages?.[0].name ?? '',
       name: ``,
       type: '',
-      teamId: team ? team.id : '',
       files: [],
     },
     validationSchema: Yup.object().shape({
       name: Yup.string().required('Name is Required'),
       language: Yup.string().required('Language is Required'),
-      type: Yup.string().required('Type Required'),
-      teamId: Yup.string().required('Type Required'),
+      type: Yup.string().required('Type Required')
     }),
     onSubmit: async (values) => {
       try {
@@ -58,7 +56,7 @@ const CreateTask = ({
             language: values.language,
             type: values.type,
             name: values.name,
-            teamId: values.teamId,
+            teamId: team ? team.id : '',
             status: 'CREATED',
             userId: '',
             createdAt: new Date(),

--- a/pages/teams/[slug]/tasks/[id]/transcripts.tsx
+++ b/pages/teams/[slug]/tasks/[id]/transcripts.tsx
@@ -8,7 +8,7 @@ import { useRouter } from 'next/router';
 import useTask from 'hooks/useTask';
 import AllTranscripts from '@/components/transcripts/Transcripts';
 import { Button } from 'react-daisyui';
-import { CreateTask, TasksTab } from '@/components/tasks';
+import { TasksTab } from '@/components/tasks';
 import { useState } from 'react';
 
 const Transcripts: NextPageWithLayout = () => {
@@ -40,7 +40,7 @@ const Transcripts: NextPageWithLayout = () => {
             color="primary"
             size="md"
             onClick={() => {
-              // setVisible(!visible);
+              setVisible(!visible);
 
             }}
           >
@@ -48,7 +48,6 @@ const Transcripts: NextPageWithLayout = () => {
           </Button>
         </div>
         <AllTranscripts task={task} />
-        <CreateTask visible={visible} setVisible={setVisible} />
 
       </div>
      

--- a/types/base.ts
+++ b/types/base.ts
@@ -142,7 +142,6 @@ export interface NewTaskInput {
   language: string;
   name: string;
   type: string;
-  teamId: string;
   files?: [];
 }
 


### PR DESCRIPTION
fix(CreateTask.tsx): remove unnecessary teamId field from initial form values and validation schema
fix(CreateTask.tsx): set teamId field to team.id only if team exists to prevent errors
fix(transcripts.tsx): remove unused import of CreateTask component
fix(transcripts.tsx): uncomment setVisible(!visible) to toggle visibility of CreateTask component